### PR TITLE
FreeCADWeb.Org ➞ FreeCAD.Org

### DIFF
--- a/build.md
+++ b/build.md
@@ -100,7 +100,7 @@ and then append
 `--croot /tmp/fcbuild` to your conda build command.
 >   sources:  
 >   https://github.com/conda/conda-build/issues/1331  
->   https://forum.freecadweb.org/viewtopic.php?f=10&t=12534&start=280#p155440
+>   https://forum.freecad.org/viewtopic.php?f=10&t=12534&start=280#p155440
 
 ### Hosting FreeCAD packages
 


### PR DESCRIPTION
This PR updates references to the
old FreeCAD site with new ones.

FYI, domains don't mind the casing.